### PR TITLE
Expose `db_instance_storage_type` for alicloud_db_instance resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ resource "alicloud_db_instance" "this" {
   engine                     = var.engine
   engine_version             = var.engine_version
   instance_type              = var.instance_type
+  db_instance_storage_type   = var.instance_storage_type
   instance_storage           = var.instance_storage
   instance_charge_type       = var.instance_charge_type
   instance_name              = var.instance_name

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,13 @@ variable "period" {
   type        = number
   default     = 1
 }
+
+variable "instance_storage_type" {
+  description = "The storage type of DB instance"
+  type        = string
+  default     = "local_ssd"
+}
+
 variable "instance_storage" {
   description = "The storage capacity of the instance. Unit: GB. The storage capacity increases at increments of 5 GB. For more information, see [Instance Types](https://www.alibabacloud.com/help/doc-detail/26312.htm)."
   type        = number


### PR DESCRIPTION
Enable users to set `db_instance_storage_type`. This can fix the issue
happended since Sept. 14, 2021.

{"Code":"InvalidNetworkTypeClassicWhenCloudStorage","HostId":
"rds.aliyuncs.com","Message":"The Specified InstanceNetworkType
value Classic is not valid when choose cloud storage type."